### PR TITLE
Allow characters in db connection string

### DIFF
--- a/lib/jackfs/adapters/db_adapter.rb
+++ b/lib/jackfs/adapters/db_adapter.rb
@@ -22,8 +22,8 @@ module Jackfs
       FileUtils.mkdir_p temp_file_path
 
       yml = YAML.load_file(config_file)[@app_env.to_s]
-      @connection = uri_escape(yml["connection"])
-      @table_name = yml["table_name"]
+      @connection ||= uri_escape(ENV["JACKFS_DB_URL"] || yml["connection"])
+      @table_name ||= ENV["JACKFS_TABLE_NAME"] || yml["table_name"]
 
       # Clean up temp files
       FileUtils.remove_file(File.join(temp_file_path,'/*'), true)

--- a/lib/jackfs/adapters/db_adapter.rb
+++ b/lib/jackfs/adapters/db_adapter.rb
@@ -22,8 +22,8 @@ module Jackfs
       FileUtils.mkdir_p temp_file_path
 
       yml = YAML.load_file(config_file)[@app_env.to_s]
-      @connection ||= uri_escape(ENV["JACKFS_DB_URL"] || yml["connection"])
-      @table_name ||= ENV["JACKFS_TABLE_NAME"] || yml["table_name"]
+      @connection = uri_escape(yml["connection"])
+      @table_name = yml["table_name"]
 
       # Clean up temp files
       FileUtils.remove_file(File.join(temp_file_path,'/*'), true)

--- a/lib/jackfs/adapters/db_adapter.rb
+++ b/lib/jackfs/adapters/db_adapter.rb
@@ -1,5 +1,6 @@
 require 'base64'
 require 'fileutils'
+require 'uri'
 
 begin
   require 'sequel/no_core_ext'
@@ -21,7 +22,7 @@ module Jackfs
       FileUtils.mkdir_p temp_file_path
 
       yml = YAML.load_file(config_file)[@app_env.to_s]
-      @connection = yml["connection"]
+      @connection = uri_escape(yml["connection"])
       @table_name = yml["table_name"]
 
       # Clean up temp files
@@ -72,6 +73,14 @@ module Jackfs
     def config_file
       File.join(@app_root, Jackfs::FileStore::CONFIG_FILE)
     end
+
+    def uri_escape(uri)
+      begin
+        URI.escape(uri)
+      rescue Exception => e
+        $stdout.puts "Error encountered when parsing #{uri} - #{e.message}"
+      end
+    end    
 
   end
 end

--- a/lib/jackfs/adapters/db_adapter.rb
+++ b/lib/jackfs/adapters/db_adapter.rb
@@ -37,6 +37,7 @@ module Jackfs
         :created_at => Time.now,
         :updated_at => Time.now
       )
+      name
     end
 
     def get(name)

--- a/lib/jackfs/version.rb
+++ b/lib/jackfs/version.rb
@@ -1,3 +1,3 @@
 module Jackfs
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/spec/adapters/db_adapter_spec.rb
+++ b/spec/adapters/db_adapter_spec.rb
@@ -25,7 +25,7 @@ describe "Jackfs Db Adapter" do
   end
 
   it "should save the file in db using the given name" do
-    @dba.store(File.open(File.dirname(__FILE__) + '/../fixtures/test.pdf', 'r'),"COOLBEANS").should eq(1)
+    @dba.store(File.open(File.dirname(__FILE__) + '/../fixtures/test.pdf', 'r'),"COOLBEANS").should be_true
   end
   
   it "should allow connection string with odd characters" do

--- a/spec/adapters/db_adapter_spec.rb
+++ b/spec/adapters/db_adapter_spec.rb
@@ -25,7 +25,18 @@ describe "Jackfs Db Adapter" do
   end
 
   it "should save the file in db using the given name" do
-    @dba.store(File.open(File.dirname(__FILE__) + '/../fixtures/test.pdf', 'r'),"COOLBEANS").should == true
+    @dba.store(File.open(File.dirname(__FILE__) + '/../fixtures/test.pdf', 'r'),"COOLBEANS").should be_true
+  end
+  
+  it "should allow connection string with odd characters" do
+    @dba.connection = "sqlite://root:abc!#%@test.db"
+    @dba.uri_escape(@dba.connection).should eq("sqlite://root:abc!%23%25@test.db")
+  end
+  
+  it "should throw an error when connection string is bad URI" do
+    URI.stub!(:escape).and_raise(Exception)
+    $stdout.should_receive(:puts).with('Error encountered when parsing sqlite://test.db - Exception')
+    @dba.uri_escape(@dba.connection)    
   end
 
   # it "should get a file from a configured from db" do

--- a/spec/adapters/db_adapter_spec.rb
+++ b/spec/adapters/db_adapter_spec.rb
@@ -25,7 +25,7 @@ describe "Jackfs Db Adapter" do
   end
 
   it "should save the file in db using the given name" do
-    @dba.store(File.open(File.dirname(__FILE__) + '/../fixtures/test.pdf', 'r'),"COOLBEANS").should be_true
+    @dba.store(File.open(File.dirname(__FILE__) + '/../fixtures/test.pdf', 'r'),"COOLBEANS").should eq(1)
   end
   
   it "should allow connection string with odd characters" do

--- a/spec/adapters/db_adapter_spec.rb
+++ b/spec/adapters/db_adapter_spec.rb
@@ -25,7 +25,7 @@ describe "Jackfs Db Adapter" do
   end
 
   it "should save the file in db using the given name" do
-    @dba.store(File.open(File.dirname(__FILE__) + '/../fixtures/test.pdf', 'r'),"COOLBEANS").should be_true
+    @dba.store(File.open(File.dirname(__FILE__) + '/../fixtures/test.pdf', 'r'),"COOLBEANS").should eq("COOLBEANS")
   end
   
   it "should allow connection string with odd characters" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'rspec'
 require 'fileutils'
 require 'yaml'
+require 'uri'
 
 
 $: << File.join(File.dirname(__FILE__), '..', 'lib')


### PR DESCRIPTION
This will allow connection strings with problematic characters to be used, and therefore preventing parsing errors.
